### PR TITLE
feat(profile): display specific user profile using Convex data

### DIFF
--- a/src/app/profile/[profileId]/page.tsx
+++ b/src/app/profile/[profileId]/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { Id } from "../../../../convex/_generated/dataModel";
+import { LinkedInProfileCard } from "../components/LinkedInProfileCard";
+import { mapConvexDataToUserProfile } from "../page";
+
+export const ProfileCard = ({ params }: { params: { profileId: string } }) => {
+  const profile = useQuery(api.queries.getUserProfileById, {
+    userId: params.profileId as Id<"users">,
+  });
+  return <LinkedInProfileCard profile={mapConvexDataToUserProfile(profile)} profileId={"" as Id<"users">} />;
+};
+
+export default ProfileCard;

--- a/src/app/profile/components/ExperienceCard.tsx
+++ b/src/app/profile/components/ExperienceCard.tsx
@@ -1,8 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // ExperienceCard.tsx
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { FaBriefcase, FaPen } from "react-icons/fa"; // Icon for experience
+import React, { useState } from "react";
+import { FaPen } from "react-icons/fa"; // Icon for experience
 
 import { ExperienceUpdate } from "./edits/ui/ExperienceUpdate";
 import { useQuery } from "convex/react";
@@ -108,16 +109,18 @@ const SingleExperienceCard = ({
         )}
         {exp.story && <p className="mt-2 text-gray-100 italic">{exp.story}</p>}
       </div>
-      <FaPen
-        className="text-yellow-400 cursor-pointer hover:text-yellow-500"
-        onClick={() => {
-          console.log({
-            profileId: profileId,
-            exp: exp,
-          });
-          setIsExperienceDialogOpen(true);
-        }}
-      />
+      {profileId && (
+        <FaPen
+          className="text-yellow-400 cursor-pointer hover:text-yellow-500"
+          onClick={() => {
+            console.log({
+              profileId: profileId,
+              exp: exp,
+            });
+            setIsExperienceDialogOpen(true);
+          }}
+        />
+      )}
       <ExperienceUpdate
         isOpen={isExperienceDialogOpen}
         setIsOpen={setIsExperienceDialogOpen}
@@ -144,6 +147,7 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({
       <div className="mt-4 space-y-4">
         {experience.map((exp, index) => (
           <SingleExperienceCard
+            key={index}
             exp={exp}
             index={index}
             formatDateRange={formatDateRange}

--- a/src/app/profile/components/LinkedInProfileCard.tsx
+++ b/src/app/profile/components/LinkedInProfileCard.tsx
@@ -55,7 +55,7 @@ export const LinkedInProfileCard = ({
             className="rounded-lg w-full"
           />
           {/* Edit Icon */}
-          <div className="">
+          {profileId && <div className="">
             <div
               className="absolute right-4 top-4 cursor-pointer mt-1 mr-1"
               onClick={() => setIsBannerDialogOpen(true)}
@@ -69,7 +69,7 @@ export const LinkedInProfileCard = ({
               isOpen={isBannerDialogOpen}
               setIsOpen={setIsBannerDialogOpen}
             />
-          </div>
+          </div>}
           {/* Profile Photo (absolute positioned) */}
           <div className="flex -mt-12 ml-2 left-8 -bottom-12">
             <Image
@@ -95,7 +95,6 @@ export const LinkedInProfileCard = ({
             educations={profile.educations}
             formatDateRange={formatDateRange}
           />
-          s
           <SkillCard skills={profile.skills} />
           <SocialsCard socials={profile.socials} />
         </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,7 +10,7 @@ import { Profile } from "../../../types/profile.interface";
 import { LinkedInProfileCard } from "./components/LinkedInProfileCard";
 
 // Function to map Convex data to the UserProfile interface
-function mapConvexDataToUserProfile(profileData: any): Profile {
+export function mapConvexDataToUserProfile(profileData: any): Profile {
   if (profileData == null) {
     return {
       name: "",


### PR DESCRIPTION
Merge feature/additional/profile into master

- Merged the feature branch that adds support for displaying specific user profiles using Convex queries.
- Includes the `ProfileCard` component for fetching and rendering user profiles from the database.
- Ensures the profile data is properly mapped to the `LinkedInProfileCard` component for consistent UI presentation.